### PR TITLE
Added support to watch uploads

### DIFF
--- a/Contents/Strings/en.json
+++ b/Contents/Strings/en.json
@@ -37,5 +37,6 @@
     "Channel updated to version %s": "Channel updated to version %s",
     "access_token": "Access Token (optional)",
     "authorize": "Authorize",
-    "hide_offline": "Hide Offline Channels"
+    "hide_offline": "Hide Offline Channels",
+    "uploads": "Uploads"
 }


### PR DESCRIPTION
Twitch added a possibilty to upload videos a while ago. VODs can now
either be of type highlight, archive or upload. In order to be able
to see them the query must use the new 'broadcast_type' parameter.

This plugin will now display all uploads of a channel in a sepate list
similar to how it was done so far for past broadcasts or highlights.